### PR TITLE
Add requirements.txt

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -23,6 +23,10 @@ Bibliotecas utilizadas:
 - math;
 - statistics (para cálculo de desvio padrão);
 
+As bibliotecas podem ser importadas executando o comando abaixo no terminal:
+
+pip install -r requirements.txt
+
 __________________________
 
 O código está programado para cálculo de vol anualizada de janela móvel de 90 dias, que é

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,12 @@
+cycler==0.11.0
+fonttools==4.29.1
+kiwisolver==1.3.2
+matplotlib==3.5.1
+numpy==1.22.1
+packaging==21.3
+Pillow==9.0.0
+pyparsing==3.0.7
+python-dateutil==2.8.2
+six==1.16.0
+xlrd==2.0.1
+XlsxWriter==3.0.2


### PR DESCRIPTION
Conforme citei no twitter, invés de requerer que a pessoa precise coletar as bibliotecas, o python permite exportar um arquivo com as dependências de um projeto rodando:

```
pip freeze > requirements.txt
```

E depois consumir o mesmo:
```
pip install -r requirements.txt
```

Eu criei um venv pra não misturar com as bibliotecas que eu já possuía no sistema e adicionei o requirements.txt e ajustei o leia-me para explicar como usar